### PR TITLE
Allow passing a vector as an output parameter to get all possible solutions

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -3,6 +3,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <cassert>
 
 #include "solver.h"
 #include "board.h"
@@ -47,6 +48,13 @@ SolverResult Solver::solve(const Board &board, Board &solvedBoard)
 }
 
 SolverResult Solver::solve(const Board &board, const vector<uint8_t> &candidates, Board &solvedBoard) 
+{
+    vector<Board> solvedBoards;
+    return solve(board, candidates, solvedBoard, 1, solvedBoards);
+}
+
+SolverResult Solver::solve(const Board &board, const vector<uint8_t> &candidates, Board &solvedBoard,
+                           size_t maxSolutions, vector<Board> &solvedBoards)
 {
     // Checks the vector of candidate values - it must have the integers from 1 to 9 without 
     // repetition.
@@ -108,7 +116,15 @@ SolverResult Solver::solve(const Board &board, const vector<uint8_t> &candidates
                 candidatesIdx++;
             }
         }
-        if (currCellSolved)
+        // If we solved the current cell and it's the last, then we've solved the board.
+        if (currCellSolved && currCellPos == emptyCells.size()-1) {
+            assert(solvedBoard.isComplete());
+            solvedBoards.push_back(solvedBoard);
+            // We could reuse the working board to conserve memory.
+        }
+        // If we've solved all the cells, but we have not yet found as many solutions as we want,
+        // then we actually want to keep going.
+        if (currCellSolved && (currCellPos+1 < emptyCells.size() || solvedBoards.size() >= maxSolutions))
         {
             currCellPos++;
         }
@@ -133,6 +149,7 @@ SolverResult Solver::solve(const Board &board, const vector<uint8_t> &candidates
     }
     else
     {
+        assert(solvedBoard.isComplete());
         return SolverResult::NO_ERROR;
     }
 }

--- a/src/solver.h
+++ b/src/solver.h
@@ -74,6 +74,9 @@ public:
      */
     SolverResult solve(const Board &board, const std::vector<uint8_t> &candidates,
                        Board &solvedBoard);
+    SolverResult solve(const Board &board, const std::vector<uint8_t> &candidates,
+                       Board &solvedBoard,
+                       size_t maxSolutions, std::vector<Board> &solvedBoards);
 
     /**
      * Assynchronously finds all the solutions for a Sudoku puzzle in a given board, 


### PR DESCRIPTION
So, caveat that I may be totally misunderstanding what you're trying to do with `Solver::solveForGood`, but I was looking at `Solver::solve` and it looks like we could get *all* solutions with minimal changes.

This might be more efficient than calling `Solver::solve` repeatedly.
(Of course, this branch only has the solution part, not all the asynchronous callbacks. I figured it would be clearer to look at this way, only changing a few lines of `Solver::solve`. We could integrate the async callbacks in as optional parameters, depending on how you wanted that all to work.)

This branch demonstrates how to make `Solver::solve` return multiple solutions, and the branch of the same name in the Python wrapper shows a use of it. That one would be a bit hard to read as a pull request since it includes the files from https://github.com/raulcostajunior/py_libsudoku/pull/2 needed for tox testing, but you can see the key part here: https://github.com/raulcostajunior/py_libsudoku/commit/edce97ef2413ba40ea101b5af76a8823a22837d9

As you can see, `Solver::solve` can still be used with the original signature. There's a tiny bit of inefficiency as things stand here, since it creates a useless vector in that case. If that bothers you, I'm sure there are shenanigans we can pull to avoid creating a vector in the case where we only want one solution. (Of course, if you like the look of this, we *could* potentially get rid of the `Board &solvedBoard` parameter instead, and make the vector the standard way to return solutions, with a separate convenience wrapper if you only want one solution returned.)

With this, we can then count the number of solutions: https://github.com/dHannasch/libsudoku/commit/89e52d22b4ffb94da719652a56a6020bf366d66a
And of course we can call that from Python: https://github.com/dHannasch/py_libsudoku/commit/fa001ef7baeb7bbf25bd2250e8722b320ea20b25