### PR TITLE
Allow manipulating Boards as NumPy arrays from Python.

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -236,6 +236,11 @@ Board &Board::operator=(const Board &board) noexcept
     return *this;
 }
 
+uint8_t* Board::buffer_protocol_array_access() noexcept
+{
+    return &_values[0][0];
+}
+
 ostream &operator<<(ostream &os, const Board &board)
 {
     for (uint8_t lin = 0; lin < 9; lin++)

--- a/src/board.h
+++ b/src/board.h
@@ -84,6 +84,8 @@ public:
 
     Board &operator=(const Board &board) noexcept;
 
+    std::uint8_t* buffer_protocol_array_access() noexcept;
+
 private:
     std::uint8_t _values[9][9]{
         {0, 0, 0, 0, 0, 0, 0, 0, 0},


### PR DESCRIPTION
This enables accessing Boards as NumPy arrays, as shown in https://github.com/dHannasch/py_libsudoku/commit/2e8ad0b473028f5c2859137a9b38ca8a12c1d8c7.