### PR TITLE
Refactor to extract function

### DIFF
--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -99,7 +99,7 @@ vector<uint8_t> Generator::randomPermutationOfIntegers(GeneratorFinishedCallback
 
         if (processGenCancelled(fnFinished)) 
         {
-            return;
+            return candidates;
         }
     }
     // Looks for last missing value to add to candidates vector.

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -85,21 +85,10 @@ GeneratorResult Generator::asyncGenerate(PuzzleDifficulty difficulty,
     return GeneratorResult::AsyncGenSubmitted;
 }
 
-void Generator::generate(PuzzleDifficulty difficulty,
-                         GeneratorProgressCallback fnProgress,
-                         GeneratorFinishedCallback fnFinished)
+vector<uint8_t> Generator::randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished)
 {
     srand(static_cast<unsigned int>(time(nullptr)));
 
-    const uint8_t totalSteps = 4;
-    uint8_t currentStep = 1;
-
-    if (fnProgress != nullptr) 
-    {
-        fnProgress(currentStep, totalSteps);
-    }
-
-    // Generate random candidates values vector.
     vector<uint8_t> candidates;
     while (candidates.size() < 8) {
         uint8_t val =rand()%9 + 1;
@@ -123,6 +112,24 @@ void Generator::generate(PuzzleDifficulty difficulty,
                                   find(valuesPresent.cbegin(), valuesPresent.cend(), false)) + 1);
     candidates.push_back(missingVal);
 
+    return candidates;
+}
+
+void Generator::generate(PuzzleDifficulty difficulty,
+                         GeneratorProgressCallback fnProgress,
+                         GeneratorFinishedCallback fnFinished)
+{
+    const uint8_t totalSteps = 4;
+    uint8_t currentStep = 1;
+
+    if (fnProgress != nullptr)
+    {
+        fnProgress(currentStep, totalSteps);
+    }
+
+    // Generate random candidates values vector.
+    vector<uint8_t> candidates = randomPermutationOfIntegers(fnFinished);
+
     currentStep++;
     if (fnProgress != nullptr) 
     {
@@ -131,6 +138,7 @@ void Generator::generate(PuzzleDifficulty difficulty,
 
     // Initializes the generated board with a random value at a random position.
     Board genBoard;
+    srand(static_cast<unsigned int>(time(nullptr)));
     uint8_t initPosition = rand()%81;
     genBoard.setValueAt(initPosition/9, initPosition%9, candidates[5]);
     if (processGenCancelled(fnFinished)) {

--- a/src/generator.h
+++ b/src/generator.h
@@ -73,6 +73,8 @@ public:
 
 private:
 
+    vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
+
     void generate(PuzzleDifficulty difficulty,
                   GeneratorProgressCallback fnProgress,
                   GeneratorFinishedCallback fnFinished);

--- a/src/generator.h
+++ b/src/generator.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace sudoku
 {
@@ -73,7 +74,7 @@ public:
 
 private:
 
-    vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
+    std::vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
 
     void generate(PuzzleDifficulty difficulty,
                   GeneratorProgressCallback fnProgress,


### PR DESCRIPTION
Would you be interested in breaking the monolithic generate() function into parts?

This extracts the initial part of generation, which simply generates a random permutation of the integers from 1 to 9, into its own separate function randomPermutationOfIntegers().

I was thinking of potentially extracting almost the entire generate() function into a synchronous function returning the Board genBoard, so that the main generate() function simply calls the inner function and then calls fnFinished on the resulting Board. That would optionally allow us to also easily generate a Board synchronously (with a null fnProgress), for when we don't want to worry about asynchronous calls. I'm not sure if there's some obvious reason I'm missing why that would be a bad idea.