### PR TITLE
Extract function to generate random valid filled Sudoku board

### DIFF
--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -99,7 +99,7 @@ vector<uint8_t> Generator::randomPermutationOfIntegers(GeneratorFinishedCallback
 
         if (processGenCancelled(fnFinished)) 
         {
-            return;
+            return candidates;
         }
     }
     // Looks for last missing value to add to candidates vector.

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -127,7 +127,7 @@ Board Generator::fullSudokuBoardGivenCandidates(vector<uint8_t> candidates,
     uint8_t initPosition = rand()%81;
     genBoard.setValueAt(initPosition/9, initPosition%9, candidates[5]);
     if (processGenCancelled(fnFinished)) {
-        return;
+        return genBoard;
     }
 
     currentStep++;

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -85,21 +85,10 @@ GeneratorResult Generator::asyncGenerate(PuzzleDifficulty difficulty,
     return GeneratorResult::AsyncGenSubmitted;
 }
 
-void Generator::generate(PuzzleDifficulty difficulty,
-                         GeneratorProgressCallback fnProgress,
-                         GeneratorFinishedCallback fnFinished)
+vector<uint8_t> Generator::randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished)
 {
     srand(static_cast<unsigned int>(time(nullptr)));
 
-    const uint8_t totalSteps = 4;
-    uint8_t currentStep = 1;
-
-    if (fnProgress != nullptr) 
-    {
-        fnProgress(currentStep, totalSteps);
-    }
-
-    // Generate random candidates values vector.
     vector<uint8_t> candidates;
     while (candidates.size() < 8) {
         uint8_t val =rand()%9 + 1;
@@ -123,6 +112,24 @@ void Generator::generate(PuzzleDifficulty difficulty,
                                   find(valuesPresent.cbegin(), valuesPresent.cend(), false)) + 1);
     candidates.push_back(missingVal);
 
+    return candidates;
+}
+
+void Generator::generate(PuzzleDifficulty difficulty,
+                         GeneratorProgressCallback fnProgress,
+                         GeneratorFinishedCallback fnFinished)
+{
+    const uint8_t totalSteps = 4;
+    uint8_t currentStep = 1;
+
+    if (fnProgress != nullptr)
+    {
+        fnProgress(currentStep, totalSteps);
+    }
+
+    // Generate random candidates values vector.
+    vector<uint8_t> candidates = randomPermutationOfIntegers(fnFinished);
+
     currentStep++;
     if (fnProgress != nullptr) 
     {
@@ -131,6 +138,7 @@ void Generator::generate(PuzzleDifficulty difficulty,
 
     // Initializes the generated board with a random value at a random position.
     Board genBoard;
+    srand(static_cast<unsigned int>(time(nullptr)));
     uint8_t initPosition = rand()%81;
     genBoard.setValueAt(initPosition/9, initPosition%9, candidates[5]);
     if (processGenCancelled(fnFinished)) {

--- a/src/generator.h
+++ b/src/generator.h
@@ -75,6 +75,11 @@ private:
 
     vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
 
+    Board fullSudokuBoardGivenCandidates(vector<uint8_t> candidates,
+                                         GeneratorProgressCallback fnProgress,
+                                         GeneratorFinishedCallback fnFinished,
+                                         uint8_t& currentStep, const uint8_t totalSteps);
+
     void generate(PuzzleDifficulty difficulty,
                   GeneratorProgressCallback fnProgress,
                   GeneratorFinishedCallback fnFinished);

--- a/src/generator.h
+++ b/src/generator.h
@@ -76,7 +76,7 @@ private:
 
     std::vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
 
-    Board fullSudokuBoardGivenCandidates(vector<uint8_t> candidates,
+    Board fullSudokuBoardGivenCandidates(std::vector<uint8_t> candidates,
                                          GeneratorProgressCallback fnProgress,
                                          GeneratorFinishedCallback fnFinished,
                                          uint8_t& currentStep, const uint8_t totalSteps);

--- a/src/generator.h
+++ b/src/generator.h
@@ -73,6 +73,8 @@ public:
 
 private:
 
+    vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
+
     void generate(PuzzleDifficulty difficulty,
                   GeneratorProgressCallback fnProgress,
                   GeneratorFinishedCallback fnFinished);

--- a/src/generator.h
+++ b/src/generator.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace sudoku
 {
@@ -73,7 +74,7 @@ public:
 
 private:
 
-    vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
+    std::vector<uint8_t> randomPermutationOfIntegers(GeneratorFinishedCallback fnFinished);
 
     void generate(PuzzleDifficulty difficulty,
                   GeneratorProgressCallback fnProgress,


### PR DESCRIPTION
Continuing from #4, this extracts a function to generate the random valid filled Sudoku board before removing some positions.

This might actually be a little easier to view like this, as a single pull request together with extracting the randomPermutationOfIntegers function, rather than separately, because although the diff still gets a little confused, it notices in at least a lot of cases that the lines of code haven't changed.