### PR TITLE
Add .travis.yml to enable CI testing on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+
+before_install:
+  - cmake --version
+  - make --version
+  - uname -a
+  - lsb_release -a
+
+install:
+  - cmake .
+  - make
+
+script:
+  - make test


### PR DESCRIPTION
Minimal .travis.yml so you can enable Travis if you want. I tried it out at https://travis-ci.com/dHannasch/libsudoku and it works.