### PR TITLE
Multiple board implementations

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -278,6 +278,9 @@ SetValueResult BoardWithBitSets<SmallSquareSide>::setValueAt(std::uint8_t line, 
     BoardWithBitSets<SmallSquareSide> valueSetBoard(*this);
     valueSetBoard._values.at(line).at(column) = value;
     // if (valueSetBoard.isValid()) {
+    // Is there any good swift way to check whether the board is still valid/solvable?
+    // We could of course try to solve it, but that would take quite a while if we did that every time.
+    // But that might be the only way...
     if (true) {
         // Value won't invalidate the board, so go ahead and set it.
         _values[line][column] = value;

--- a/src/board.h
+++ b/src/board.h
@@ -15,10 +15,53 @@ enum class SetValueResult : std::uint8_t
     ValueInvalidatesBoard
 };
 
+template <typename CellValueType>
+class BoardBase
+{
+    /**
+         * Returns the side length of the small squares the board is composed
+         * of. Each of those small squares must contain all the symbols.
+         * 
+         * @return the length of one of the small squares on the board.
+         */
+    virtual std::uint8_t smallSquareSide() const noexcept = 0;
+
+    /**
+         * Retrieves the number of distinct symbols that may appear on the
+         * board.
+         * 
+         * @return the number of possible symbols.
+         */
+    std::uint8_t numberOfSymbols() const noexcept
+        { return smallSquareSide()*smallSquareSide(); };
+
+    /**
+         * Retrieves the value at a given (line, column) coordinate of the
+         * board. 
+         * 
+         * @param line the line number (starting at 0).
+         * @param column the column number (starting at 0).
+         * @return the value at position (line, column) of the board.
+         */
+    virtual CellValueType valueAt(std::uint8_t line, std::uint8_t column) const noexcept = 0;
+
+    /**
+         * Sets the value at a given (line, column) coordinate of the board. 
+         * 
+         * @param line the line number (starting at 0).
+         * @param column the column number (starting at 0).
+         * @param the value to be set at position (line, column) of the board.
+         * @return a SetValueResult indicating the result of the operation. If 
+         * the return is not SetValueResult::NoError, the board won't be changed.
+         */
+    virtual SetValueResult setValueAt(std::uint8_t line, std::uint8_t column, CellValueType value) = 0;
+
+};
+
 /**
  * @brief A 9x9 Sudoku board.
 */
-class Board
+class Board: public BoardBase<std::uint8_t>
 {
 
 public:
@@ -28,6 +71,14 @@ public:
     explicit Board(const std::vector<std::uint8_t> &values);
 
     Board(const Board &board);
+
+    /**
+         * Retrieves the length of one of the nine 3x3 squares that make up
+         * the full 9x9 board. For this class, obviously, this is always 3.
+         * 
+         * @return 3.
+         */
+    std::uint8_t smallSquareSide() const noexcept { return 3; };
 
     /**
          * Retrieves the value at a given (line, column) coordinate of the 

--- a/src/board.h
+++ b/src/board.h
@@ -4,6 +4,9 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
+#include <array>
+#include <bitset>
+#include <algorithm>
 
 namespace sudoku
 {
@@ -18,6 +21,9 @@ enum class SetValueResult : std::uint8_t
 template <typename CellValueType>
 class BoardBase
 {
+
+public:
+
     /**
          * Returns the side length of the small squares the board is composed
          * of. Each of those small squares must contain all the symbols.
@@ -37,7 +43,7 @@ class BoardBase
 
     /**
          * Retrieves the value at a given (line, column) coordinate of the
-         * board. 
+         * board.
          * 
          * @param line the line number (starting at 0).
          * @param column the column number (starting at 0).
@@ -46,15 +52,35 @@ class BoardBase
     virtual CellValueType valueAt(std::uint8_t line, std::uint8_t column) const noexcept = 0;
 
     /**
-         * Sets the value at a given (line, column) coordinate of the board. 
+         * Sets the value at a given (line, column) coordinate of the board.
          * 
          * @param line the line number (starting at 0).
          * @param column the column number (starting at 0).
          * @param the value to be set at position (line, column) of the board.
-         * @return a SetValueResult indicating the result of the operation. If 
+         * @return a SetValueResult indicating the result of the operation. If
          * the return is not SetValueResult::NoError, the board won't be changed.
          */
     virtual SetValueResult setValueAt(std::uint8_t line, std::uint8_t column, CellValueType value) = 0;
+
+    /**
+         * Clears the board.
+         */
+    virtual void clear() noexcept = 0;
+
+    /**
+        * Returns true if all the positions in the board are blank.
+        */
+    virtual bool isEmpty() const noexcept = 0;
+
+    /**
+        * Returns true if a board has no blank position and is valid -
+        * in other words, the board corresponds to a solved puzzle.
+        */
+    virtual bool isComplete() const noexcept = 0;
+
+    bool operator==(const BoardBase &board) const noexcept;
+
+    BoardBase &operator=(const BoardBase &board) noexcept;
 
 };
 
@@ -82,7 +108,7 @@ public:
 
     /**
          * Retrieves the value at a given (line, column) coordinate of the 
-         * board. 
+         * board.
          * 
          * @param line the line number (from 0 to 8).
          * @param column the column number (from 0 to 8).
@@ -93,13 +119,13 @@ public:
     std::uint8_t valueAt(std::uint8_t line, std::uint8_t column) const noexcept;
 
     /**
-         * Sets the value at a given (line, column) coordinate of the board. 
+         * Sets the value at a given (line, column) coordinate of the board.
          * 
          * @param line the line number (from 0 to 8).
          * @param column the column number (from 0 to 8).
          * @param the value to be set at position (line, column) of the board. Can
          * be a value from 0 to 9 - 0 meaning empty. 
-         * @return a SetValueResult indicating the result of the operation. If 
+         * @return a SetValueResult indicating the result of the operation. If
          * the return is not SetValueResult::NO_ERROR, the board won't be changed.
          */
     SetValueResult setValueAt(std::uint8_t line, std::uint8_t column, std::uint8_t value);
@@ -147,6 +173,145 @@ private:
         {0, 0, 0, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 0, 0, 0, 0, 0, 0}};
 };
+
+/**
+ * @brief A Sudoku board with bitsets in the cells,
+ * representing possible symbols that have not yet been eliminated for that cell.
+*/
+template <size_t SmallSquareSide>
+class BoardWithBitSets: public BoardBase<std::bitset<SmallSquareSide*SmallSquareSide>>
+{
+
+public:
+    BoardWithBitSets() { clear(); };
+
+    /**
+         * Clears the board by assigning each bitset to allow all symbols.
+         */
+    void clear() noexcept;
+
+    /**
+         * Returns the side length of the small squares the board is composed
+         * of. Each of those small squares must contain all the symbols.
+         * 
+         * @return the length of one of the small squares on the board.
+         */
+    std::uint8_t smallSquareSide() const noexcept { return SmallSquareSide; };
+
+    /**
+         * Retrieves the number of distinct symbols that may appear on the
+         * board.
+         * 
+         * @return the number of possible symbols.
+         */
+    std::uint8_t numberOfSymbols() const noexcept
+        { return smallSquareSide()*smallSquareSide(); };
+
+    /**
+        * Returns true if all the positions in the board are blank.
+        */
+    bool isEmpty() const noexcept;
+
+    /**
+        * Returns true if a board has no blank position and is valid -
+        * in other words, the board corresponds to a solved puzzle.
+        */
+    bool isComplete() const noexcept;
+
+    /**
+         * Retrieves the value at a given (line, column) coordinate of the
+         * board.
+         * 
+         * @param line the line number (starting at 0).
+         * @param column the column number (starting at 0).
+         * @return the value at position (line, column) of the board.
+         */
+    std::bitset<SmallSquareSide*SmallSquareSide> valueAt(std::uint8_t line, std::uint8_t column) const noexcept;
+
+    /**
+         * Sets the value at a given (line, column) coordinate of the board.
+         * 
+         * @param line the line number (starting at 0).
+         * @param column the column number (starting at 0).
+         * @param the value to be set at position (line, column) of the board.
+         * @return a SetValueResult indicating the result of the operation. If
+         * the return is not SetValueResult::NoError, the board won't be changed.
+         */
+    SetValueResult setValueAt(std::uint8_t line, std::uint8_t column, std::bitset<SmallSquareSide*SmallSquareSide> value);
+
+private:
+    std::array<std::array<std::bitset<SmallSquareSide*SmallSquareSide>, SmallSquareSide*SmallSquareSide>, SmallSquareSide*SmallSquareSide> _values;
+};
+
+// Templated functions must be in the header file,
+// otherwise the compiler doesn't write out all the versions you need
+// and you get "undefined reference to" errors from the linker.
+
+template <size_t SmallSquareSide>
+void BoardWithBitSets<SmallSquareSide>::clear() noexcept
+{
+    for (auto& row : _values)
+    {
+        for (std::bitset<SmallSquareSide*SmallSquareSide>& cell : row)
+        {
+            cell.set();
+        }
+    }
+}
+
+template <size_t SmallSquareSide>
+std::bitset<SmallSquareSide*SmallSquareSide> BoardWithBitSets<SmallSquareSide>::valueAt(std::uint8_t line, std::uint8_t column) const noexcept
+{
+    try
+    {
+        return _values.at(line).at(column);
+    } catch (const std::out_of_range& e)
+    {
+        return std::bitset<SmallSquareSide*SmallSquareSide>().set();
+    }
+}
+
+template <size_t SmallSquareSide>
+SetValueResult BoardWithBitSets<SmallSquareSide>::setValueAt(std::uint8_t line, std::uint8_t column, std::bitset<SmallSquareSide*SmallSquareSide> value)
+{
+    // In this case there is no need to check for an invalid value, because all bitsets of the correct size are valid.
+    BoardWithBitSets<SmallSquareSide> valueSetBoard(*this);
+    valueSetBoard._values.at(line).at(column) = value;
+    // if (valueSetBoard.isValid()) {
+    if (true) {
+        // Value won't invalidate the board, so go ahead and set it.
+        _values[line][column] = value;
+        return SetValueResult::NoError;
+    } else {
+        return SetValueResult::ValueInvalidatesBoard;
+    }
+
+    return SetValueResult::NoError;
+}
+
+template <size_t SmallSquareSide>
+bool BoardWithBitSets<SmallSquareSide>::isEmpty() const noexcept
+{
+    return std::none_of(_values.begin(), _values.end(), [](const std::array<std::bitset<SmallSquareSide*SmallSquareSide>, SmallSquareSide*SmallSquareSide> row)
+    {
+        return std::any_of(row.begin(), row.end(), [](const std::bitset<SmallSquareSide*SmallSquareSide> cell)
+        {
+            return !cell.all();
+        });
+    });
+}
+
+template <size_t SmallSquareSide>
+bool BoardWithBitSets<SmallSquareSide>::isComplete() const noexcept
+{
+    return std::none_of(_values.begin(), _values.end(), [](const std::array<std::bitset<SmallSquareSide*SmallSquareSide>, SmallSquareSide*SmallSquareSide> row)
+    {
+        return std::any_of(row.begin(), row.end(), [](const std::bitset<SmallSquareSide*SmallSquareSide> cell)
+        {
+            return cell.count() != 1;
+        });
+    });
+}
 
 } // namespace sudoku
 

--- a/src/board.h
+++ b/src/board.h
@@ -108,7 +108,7 @@ public:
 
     /**
          * Retrieves the value at a given (line, column) coordinate of the 
-         * board.
+         * board. 
          * 
          * @param line the line number (from 0 to 8).
          * @param column the column number (from 0 to 8).
@@ -119,13 +119,13 @@ public:
     std::uint8_t valueAt(std::uint8_t line, std::uint8_t column) const noexcept;
 
     /**
-         * Sets the value at a given (line, column) coordinate of the board.
+         * Sets the value at a given (line, column) coordinate of the board. 
          * 
          * @param line the line number (from 0 to 8).
          * @param column the column number (from 0 to 8).
          * @param the value to be set at position (line, column) of the board. Can
          * be a value from 0 to 9 - 0 meaning empty. 
-         * @return a SetValueResult indicating the result of the operation. If
+         * @return a SetValueResult indicating the result of the operation. If 
          * the return is not SetValueResult::NO_ERROR, the board won't be changed.
          */
     SetValueResult setValueAt(std::uint8_t line, std::uint8_t column, std::uint8_t value);

--- a/test/board_tests.cpp
+++ b/test/board_tests.cpp
@@ -179,3 +179,9 @@ TEST_CASE("Proper set value is accepted")
     REQUIRE((result == SetValueResult::NoError));
     REQUIRE(board.valueAt(0, 4) == 4);
 }
+
+TEST_CASE("BoardWithBitSets initially empty")
+{
+    BoardWithBitSets<3> board;
+    REQUIRE(board.isEmpty());
+}


### PR DESCRIPTION
This is a first pass at abstracting the Board class to allow multiple implementations.
In particular, the new sibling class BoardWithBitSets maintains bit sets for each cell instead of simple integers.
Thus, instead of a cell having a single state --- filled or not filled --- each cell has a set of possible symbols that *could* fill it. Initially, with an empty board, any cell could contain any symbol. The board is solved when each of those sets gets reduced down to a single remaining element. The idea is ultimately to enable more piecemeal solving techniques.

(It's also using template magic to enable smaller or larger boards.)